### PR TITLE
Fixed undefined index in diagnostics.

### DIFF
--- a/app/code/community/ShipStream/Magento1/Plugin.php
+++ b/app/code/community/ShipStream/Magento1/Plugin.php
@@ -31,10 +31,10 @@ class ShipStream_Magento1_Plugin extends Plugin_Abstract
     {
         $info = $this->_magentoApi('magento.info');
         $lines = [];
-        $lines[] = sprintf('Magento Edition: %s', $info['magento_edition']);
-        $lines[] = sprintf('Magento Version: %s', $info['magento_version']);
-        $lines[] = sprintf('OpenMage Version: %s', $info['openmage_version']);
-        $lines[] = sprintf('ShipStream Sync Version: %s', $info['shipstream_sync_version']);
+        $lines[] = sprintf('Magento Edition: %s', $info['magento_edition'] ?? 'undefined');
+        $lines[] = sprintf('Magento Version: %s', $info['magento_version'] ?? 'undefined');
+        $lines[] = sprintf('OpenMage Version: %s', $info['openmage_version'] ?? 'undefined');
+        $lines[] = sprintf('ShipStream Sync Version: %s', $info['shipstream_sync_version'] ?? 'undefined');
         return $lines;
     }
     


### PR DESCRIPTION
```bash
kiatng@win10:~/shipstream/middleware$ bin/mwrun ShipStream_Magento1 --diagnostics
Creating middleware_cli_run ... done

Diagnostic information for ShipStream_Magento1 reported at 2021-05-26T04:30:21+00:00
---------------------------------------------------------------------------------
Connection is configured.

Notice: Undefined index: openmage_version in /var/www/html/.modman/plugin-openmage/app/code/community/ShipStream/Magento1/Plugin.php on line 36

Notice: Undefined index: shipstream_sync_version in /var/www/html/.modman/plugin-openmage/app/code/community/ShipStream/Magento1/Plugin.php on line 37
Magento Edition: Community
Magento Version: 1.9.4.5
OpenMage Version: 
ShipStream Sync Version: 
---------------------------------------------------------------------------------
```
