### PR TITLE
Fixed uncaught exception in sync_orders.

### DIFF
--- a/app/code/community/ShipStream/Magento1/Plugin.php
+++ b/app/code/community/ShipStream/Magento1/Plugin.php
@@ -238,14 +238,14 @@ class ShipStream_Magento1_Plugin extends Plugin_Abstract
                 // Update Magento order status and add comment
                 $this->_magentoApi('order.addComment', [$magentoOrder['increment_id'], 'submitted', $message]);
             } catch (Throwable $e) {
-                $message = sprintf('Order could not be submitted due to a script error: %s', $e->getMessage());
+                $message = sprintf('Order could not be submitted due to the following error: %s', $e->getMessage());
                 $this->log($message);
                 try {
                     $this->_magentoApi('order.addComment', [$magentoOrder['increment_id'], 'failed_to_submit', $message]);
                     $message = sprintf('Status of order # %s was changed to "failed_to_submit" in merchant site', $magentoOrder['increment_id']);
                     $this->log($message);
                 } catch (Throwable $t) {
-                    $message = sprintf('Order status could not be changed in merchant site due to a script error: %s', $e->getMessage());
+                    $message = sprintf('Order status could not be changed in merchant site due to the following error: %s', $e->getMessage());
                     $this->log($message);
                 }
             }


### PR DESCRIPTION
Exception in API to ShipStream, `$this->call('order.create')`, is thrown as `Exception`, but it is not caught in 

https://github.com/ShipStream/plugin-openmage/blob/2fde283766a57a5c85d360f52a95a59750ebf210/app/code/community/ShipStream/Magento1/Plugin.php#L233-L245

As a result, subsequent order status changed in mercahnt site was not carried out. This PR added more message logging and used PHP7 throwable exceptions only for the above `try...catch` block.  Other `try...catch` blocks in the plugin need to be reviewed.